### PR TITLE
Fix docblock to match getNamespace signature

### DIFF
--- a/Manager/BagManagerConfigurationInterface.php
+++ b/Manager/BagManagerConfigurationInterface.php
@@ -18,7 +18,9 @@ interface BagManagerConfigurationInterface
      * Gets a session namespace from a namespace key.
      * A session namespace is a key in $_SESSION array.
      *
-     * @return array
+     * @param string $key
+     * 
+     * @return string
      */
     public function getNamespace($key);
 


### PR DESCRIPTION
`BagManagerConfigurationInterface::getNamespace` would return a string instead of an array. Also the `@param` definition is missing.
