### PR TITLE
Add Symfony 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-foundation": "~2.1",
-        "symfony/http-kernel": "~2.1",
-        "symfony/config": "~2.1",
-        "symfony/event-dispatcher": "~2.1"
+        "symfony/http-foundation": "~2.1|~3.0",
+        "symfony/http-kernel": "~2.1|~3.0",
+        "symfony/config": "~2.1|~3.0",
+        "symfony/event-dispatcher": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "symfony/dependency-injection": "~2.1",
-        "symfony/yaml": "~2.1"
+        "symfony/dependency-injection": "~2.1|~3.0",
+        "symfony/yaml": "~2.1|~3.0"
     },
     "minimum-stability": "dev",
     "target-dir": "Theodo/Evolution/Bundle/SessionBundle",


### PR DESCRIPTION
This updates the version constraint for the various symfony packages to allow symfony 3 to be used.

Implements #27.
